### PR TITLE
DEVOPS-123762 - add Authentication parameter to Register- and Set-PSResourceRepository cmdlets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ src/code/obj
 srcOld/code/bin
 srcOld/code/obj
 out
+result.pester.xml

--- a/src/code/PSRepositoryInfo.cs
+++ b/src/code/PSRepositoryInfo.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections;
 using System.Management.Automation;
 
 namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
@@ -13,12 +14,13 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
     {
         #region Constructor
 
-        public PSRepositoryInfo(string name, Uri url, int priority, bool trusted)
+        public PSRepositoryInfo(string name, Uri url, int priority, bool trusted, Hashtable authentication)
         {
             Name = name;
             Url = url;
             Priority = priority;
             Trusted = trusted;
+            Authentication = authentication;
         }
 
         #endregion
@@ -44,6 +46,11 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
         /// </summary>
         [ValidateRange(0, 50)]
         public int Priority { get; }
+
+        /// <summary>
+        /// the Authentication for the repository
+        /// </summary>
+        public Hashtable Authentication { get; }
 
         #endregion
     }

--- a/src/code/RepositorySettings.cs
+++ b/src/code/RepositorySettings.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -28,6 +29,8 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
         private static readonly string RepositoryPath = Path.Combine(Environment.GetFolderPath(SpecialFolder.LocalApplicationData), "PowerShellGet");
         private static readonly string FullRepositoryPath = Path.Combine(RepositoryPath, RepositoryFileName);
 
+        private static readonly string VaultNameAttribute = "VaultName";
+        private static readonly string SecretAttribute = "Secret";
 
         /// <summary>
         /// Check if repository store xml file exists, if not then create
@@ -70,7 +73,7 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
         /// Returns: PSRepositoryInfo containing information about the repository just added to the repository store
         /// </summary>
         /// <param name="sectionName"></param>
-        public static PSRepositoryInfo Add(string repoName, Uri repoURL, int repoPriority, bool repoTrusted)
+        public static PSRepositoryInfo Add(string repoName, Uri repoURL, int repoPriority, bool repoTrusted, Hashtable repoAuthentication)
         {
             Dbg.Assert(!string.IsNullOrEmpty(repoName), "Repository name cannot be null or empty");
             Dbg.Assert(!string.IsNullOrEmpty(repoURL.ToString()), "Repository URL cannot be null or empty");
@@ -97,6 +100,16 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
                     new XAttribute("Trusted", repoTrusted)
                     );
 
+                if(repoAuthentication != null) {
+                    Dbg.Assert(repoAuthentication.ContainsKey(VaultNameAttribute), "Authentication has to contain Vault Name");
+                    Dbg.Assert(!string.IsNullOrEmpty(repoAuthentication[VaultNameAttribute].ToString()), "Vault Name cannot be null or empty");
+                    Dbg.Assert(repoAuthentication.ContainsKey(SecretAttribute), "Authentication has to contain Secret");
+                    Dbg.Assert(!string.IsNullOrEmpty(repoAuthentication[SecretAttribute].ToString()), "Secret cannot be null or empty");
+
+                    newElement.Add(new XAttribute(VaultNameAttribute, repoAuthentication[VaultNameAttribute]));
+                    newElement.Add(new XAttribute(SecretAttribute, repoAuthentication[SecretAttribute]));
+                }
+
                 root.Add(newElement);
 
                 // Close the file
@@ -107,14 +120,14 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
                 throw new PSInvalidOperationException(String.Format("Adding to repository store failed: {0}", e.Message));
             }
 
-            return new PSRepositoryInfo(repoName, repoURL, repoPriority, repoTrusted);
+            return new PSRepositoryInfo(repoName, repoURL, repoPriority, repoTrusted, repoAuthentication);
         }
 
         /// <summary>
         /// Updates a repository name, URL, priority, or installation policy
         /// Returns:  void
         /// </summary>
-        public static PSRepositoryInfo Update(string repoName, Uri repoURL, int repoPriority, bool? repoTrusted)
+        public static PSRepositoryInfo Update(string repoName, Uri repoURL, int repoPriority, bool? repoTrusted, Hashtable repoAuthentication)
         {
             Dbg.Assert(!string.IsNullOrEmpty(repoName), "Repository name cannot be null or empty");
 
@@ -154,16 +167,49 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
                     node.Attribute("Trusted").Value = repoTrusted.ToString();
                 }
 
+                // A null Authentication value passed in signifies that Authentication information was not attempted to be set.
+                // So only set VaultName and Secret attributes if non-null value passed in for repoAuthentication
+                if (repoAuthentication != null)
+                {
+                    Dbg.Assert(repoAuthentication.ContainsKey(VaultNameAttribute), "Authentication has to contain Vault Name");
+                    Dbg.Assert(!string.IsNullOrEmpty(repoAuthentication[VaultNameAttribute].ToString()), "Vault Name cannot be null or empty");
+                    Dbg.Assert(repoAuthentication.ContainsKey(SecretAttribute), "Authentication has to contain Secret");
+                    Dbg.Assert(!string.IsNullOrEmpty(repoAuthentication[SecretAttribute].ToString()), "Secret cannot be null or empty");
+
+                    if (node.Attribute(VaultNameAttribute) == null) {
+                        node.Add(new XAttribute(VaultNameAttribute, repoAuthentication[VaultNameAttribute]));
+                    }
+                    else {
+                        node.Attribute(VaultNameAttribute).Value = repoAuthentication[VaultNameAttribute].ToString();
+                    }
+
+                    if (node.Attribute(SecretAttribute) == null) {
+                        node.Add(new XAttribute(SecretAttribute, repoAuthentication[SecretAttribute]));
+                    }
+                    else {
+                        node.Attribute(SecretAttribute).Value = repoAuthentication[SecretAttribute].ToString();
+                    }
+                }
+
                 // Create Uri from node Url attribute to create PSRepositoryInfo item to return.
                 if (!Uri.TryCreate(node.Attribute("Url").Value, UriKind.Absolute, out Uri thisUrl))
                 {
                     throw new PSInvalidOperationException(String.Format("Unable to read incorrectly formatted URL for repo {0}", repoName));
                 }
 
+                // Create Authentication based on new values or whether it was empty to begin with
+                Hashtable thisAuthentication = !string.IsNullOrEmpty(node.Attribute(VaultNameAttribute)?.Value) && !string.IsNullOrEmpty(node.Attribute(SecretAttribute)?.Value)
+                    ? new Hashtable() {
+                        { VaultNameAttribute, node.Attribute(VaultNameAttribute).Value },
+                        { SecretAttribute, node.Attribute(SecretAttribute).Value }
+                    }
+                    : null;
+
                 updatedRepo = new PSRepositoryInfo(repoName,
                     thisUrl,
                     Int32.Parse(node.Attribute("Priority").Value),
-                    Boolean.Parse(node.Attribute("Trusted").Value));
+                    Boolean.Parse(node.Attribute("Trusted").Value),
+                    thisAuthentication);
 
                 // Close the file
                 root.Save(FullRepositoryPath);
@@ -251,15 +297,42 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
                         continue;
                     }
 
+                    Hashtable thisAuthentication = null;
+                    string authErrorMessage = $"Invalid Authentication information, {VaultNameAttribute} and {SecretAttribute} should both be present and non-empty";
+                    // both keys present
+                    if (repo.Attribute(VaultNameAttribute) != null && repo.Attribute(SecretAttribute) != null) {
+                        // both values non-empty
+                        // = valid authentication
+                        if (!string.IsNullOrEmpty(repo.Attribute(VaultNameAttribute).Value) && !string.IsNullOrEmpty(repo.Attribute(SecretAttribute).Value)) {
+                            thisAuthentication = new Hashtable() {
+                                { VaultNameAttribute, repo.Attribute(VaultNameAttribute).Value },
+                                { SecretAttribute, repo.Attribute(SecretAttribute).Value }
+                            };
+                        }
+                        else {
+                            tempErrorList.Add(authErrorMessage);
+                            continue;
+                        }
+                    }
+                    // both keys are missing
+                    else if (repo.Attribute(VaultNameAttribute) == null && repo.Attribute(SecretAttribute) == null) {
+                        // = valid authentication, do nothing
+                    }
+                    // one of the keys is missing
+                    else {
+                        tempErrorList.Add(authErrorMessage);
+                        continue;
+                    }
+
                     PSRepositoryInfo currentRepoItem = new PSRepositoryInfo(repo.Attribute("Name").Value,
                         thisUrl,
                         Int32.Parse(repo.Attribute("Priority").Value),
-                        Boolean.Parse(repo.Attribute("Trusted").Value));
+                        Boolean.Parse(repo.Attribute("Trusted").Value),
+                        thisAuthentication);
 
                     foundRepos.Add(currentRepoItem);
                 }
             }
-
             else
             {
                 foreach (string repo in repoNames)
@@ -277,10 +350,38 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
                             continue;
                         }
 
+                        Hashtable thisAuthentication = null;
+                        string authErrorMessage = $"Invalid Authentication information, {VaultNameAttribute} and {SecretAttribute} should both be present and non-empty";
+                        // both keys present
+                        if (node.Attribute(VaultNameAttribute) != null && node.Attribute(SecretAttribute) != null) {
+                            // both values non-empty
+                            // = valid authentication
+                            if (!string.IsNullOrEmpty(node.Attribute(VaultNameAttribute).Value) && !string.IsNullOrEmpty(node.Attribute(SecretAttribute).Value)) {
+                                thisAuthentication = new Hashtable() {
+                                    { VaultNameAttribute, node.Attribute(VaultNameAttribute).Value },
+                                    { SecretAttribute, node.Attribute(SecretAttribute).Value }
+                                };
+                            }
+                            else {
+                                tempErrorList.Add(authErrorMessage);
+                                continue;
+                            }
+                        }
+                        // both keys are missing
+                        else if (node.Attribute(VaultNameAttribute) == null && node.Attribute(SecretAttribute) == null) {
+                            // = valid authentication, do nothing
+                        }
+                        // one of the keys is missing
+                        else {
+                            tempErrorList.Add(authErrorMessage);
+                            continue;
+                        }
+
                         PSRepositoryInfo currentRepoItem = new PSRepositoryInfo(node.Attribute("Name").Value,
                             thisUrl,
                             Int32.Parse(node.Attribute("Priority").Value),
-                            Boolean.Parse(node.Attribute("Trusted").Value));
+                            Boolean.Parse(node.Attribute("Trusted").Value),
+                            thisAuthentication);
 
                         foundRepos.Add(currentRepoItem);
                     }

--- a/test/GetPSResourceRepository.Tests.ps1
+++ b/test/GetPSResourceRepository.Tests.ps1
@@ -3,7 +3,7 @@
 
 Import-Module "$psscriptroot\PSGetTestUtils.psm1" -Force
 
-Describe "Test Register-PSResourceRepository" {
+Describe "Test Get-PSResourceRepository" {
     BeforeEach {
         Get-NewPSResourceRepositoryFile
         $tmpDir1Path = Join-Path -Path $TestDrive -ChildPath "tmpDir1"
@@ -83,6 +83,17 @@ Describe "Test Register-PSResourceRepository" {
         }
     }
 
+    It "given invalid and valid Authentication information, get valid ones and write error for non valid ones" {
+        $res = Get-PSResourceRepository -Name "psgettestlocal*" -ErrorVariable err -ErrorAction SilentlyContinue
+        $err.Count | Should -Not -Be 0
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "ErrorGettingSpecifiedRepo,Microsoft.PowerShell.PowerShellGet.Cmdlets.GetPSResourceRepository"
+
+        # should have successfully got the other valid/registered repositories with no error
+        foreach ($entry in $res) {
+            $entry.Name | Should -BeIn "psgettestlocal","psgettestlocal2"
+        }
+    }
+
     It "throw error and get no repositories when provided null Name" {
         # $errorMsg = "Cannot validate argument on parameter 'Name'. The argument is null or empty. Provide an argument that is not null or empty, and then try the command again."
         {Get-PSResourceRepository -Name $null -ErrorAction Stop} | Should -Throw -ErrorId "ParameterArgumentValidationError,Microsoft.PowerShell.PowerShellGet.Cmdlets.GetPSResourceRepository"
@@ -94,7 +105,9 @@ Describe "Test Register-PSResourceRepository" {
     }
 
     It "find all repositories if no Name provided" {
-        $res = Get-PSResourceRepository
+        # there are 2 invalid repositories
+        $res = Get-PSResourceRepository -ErrorVariable err -ErrorAction SilentlyContinue
         $res.Count | Should -BeGreaterThan 0
+        $err.Count | Should -Not -Be 0
     }
 }

--- a/test/PublishPSResource.Tests.ps1
+++ b/test/PublishPSResource.Tests.ps1
@@ -11,14 +11,14 @@ Describe "Test Publish-PSResource" {
         $tmpRepoPath = Join-Path -Path $TestDrive -ChildPath "tmpRepoPath"
         New-Item $tmpRepoPath -Itemtype directory -Force
         $testRepository = "testRepository"
-        Register-PSResourceRepository -Name $testRepository -URL $tmpRepoPath -Priority 1 -ErrorAction SilentlyContinue        
-        $script:repositoryPath = (get-psresourcerepository "testRepository").Url.AbsolutePath 
+        Register-PSResourceRepository -Name $testRepository -URL $tmpRepoPath -Priority 1 -ErrorAction SilentlyContinue
+        $script:repositoryPath = [IO.Path]::GetFullPath((get-psresourcerepository "testRepository").Url.AbsolutePath)
 
         $tmpRepoPath2 = Join-Path -Path $TestDrive -ChildPath "tmpRepoPath2"
         New-Item $tmpRepoPath2 -Itemtype directory -Force
         $testRepository2 = "testRepository2"
         Register-PSResourceRepository -Name $testRepository2 -URL $tmpRepoPath2 -ErrorAction SilentlyContinue
-        $script:repositoryPath2 = (get-psresourcerepository "testRepository2").Url.AbsolutePath 
+        $script:repositoryPath2 = [IO.Path]::GetFullPath((get-psresourcerepository "testRepository2").Url.AbsolutePath)
 
         # Create module 
         $script:tmpModulesPath = Join-Path -Path $TestDrive -ChildPath "tmpModulesPath"
@@ -132,7 +132,7 @@ Describe "Test Publish-PSResource" {
         Publish-PSResource -Path $script:PublishModuleBase -SkipDependenciesCheck
 
         $expectedPath = Join-Path -Path $script:repositoryPath -ChildPath "$script:PublishModuleName.$version.nupkg"
-        (Get-ChildItem $script:repositoryPath).FullName | select-object -Last 1 | Should -Be $expectedPath 
+        (Get-ChildItem $script:repositoryPath).FullName | select-object -Last 1 | Should -Be $expectedPath
     }
 
     <# The following tests are related to passing in parameters to customize a nuspec.

--- a/test/RegisterPSResourceRepository.Tests.ps1
+++ b/test/RegisterPSResourceRepository.Tests.ps1
@@ -11,7 +11,8 @@ Describe "Test Register-PSResourceRepository" {
         $tmpDir1Path = Join-Path -Path $TestDrive -ChildPath "tmpDir1"
         $tmpDir2Path = Join-Path -Path $TestDrive -ChildPath "tmpDir2"
         $tmpDir3Path = Join-Path -Path $TestDrive -ChildPath "tmpDir3"
-        $tmpDirPaths = @($tmpDir1Path, $tmpDir2Path, $tmpDir3Path)
+        $tmpDir4Path = Join-Path -Path $TestDrive -ChildPath "tmpDir4"
+        $tmpDirPaths = @($tmpDir1Path, $tmpDir2Path, $tmpDir3Path, $tmpDir4Path)
         Get-NewTestDirs($tmpDirPaths)
     }
     AfterEach {
@@ -19,7 +20,8 @@ Describe "Test Register-PSResourceRepository" {
         $tmpDir1Path = Join-Path -Path $TestDrive -ChildPath "tmpDir1"
         $tmpDir2Path = Join-Path -Path $TestDrive -ChildPath "tmpDir2"
         $tmpDir3Path = Join-Path -Path $TestDrive -ChildPath "tmpDir3"
-        $tmpDirPaths = @($tmpDir1Path, $tmpDir2Path, $tmpDir3Path)
+        $tmpDir4Path = Join-Path -Path $TestDrive -ChildPath "tmpDir4"
+        $tmpDirPaths = @($tmpDir1Path, $tmpDir2Path, $tmpDir3Path, $tmpDir4Path)
         Get-RemoveTestDirs($tmpDirPaths)
     }
 
@@ -45,6 +47,16 @@ Describe "Test Register-PSResourceRepository" {
         $res.URL | Should -Contain $tmpDir1Path
         $res.Trusted | Should -Be True
         $res.Priority | Should -Be 20
+    }
+
+    It "register repository given Name, URL, Trusted, Priority, Authentication (NameParameterSet)" {
+        $res = Register-PSResourceRepository -Name "testRepository" -URL $tmpDir1Path -Trusted -Priority 20 -Authentication @{VaultName = "testvault"; Secret = "testsecret"} -PassThru
+        $res.Name | Should -Be "testRepository"
+        $res.URL | Should -Contain $tmpDir1Path
+        $res.Trusted | Should -Be True
+        $res.Priority | Should -Be 20
+        $res.Authentication["VaultName"] | Should -Be "testvault"
+        $res.Authentication["Secret"] | Should -Be "testsecret"
     }
 
     It "register repository with PSGallery parameter (PSGalleryParameterSet)" {
@@ -78,7 +90,8 @@ Describe "Test Register-PSResourceRepository" {
         $hashtable1 = @{Name = "testRepository"; URL = $tmpDir1Path}
         $hashtable2 = @{Name = "testRepository2"; URL = $tmpDir2Path; Trusted = $True}
         $hashtable3 = @{Name = "testRepository3"; URL = $tmpDir3Path; Trusted = $True; Priority = 20}
-        $arrayOfHashtables = $hashtable1, $hashtable2, $hashtable3
+        $hashtable4 = @{Name = "testRepository4"; URL = $tmpDir4Path; Trusted = $True; Priority = 30; Authentication = @{VaultName = "testvault"; Secret = "testsecret"}}
+        $arrayOfHashtables = $hashtable1, $hashtable2, $hashtable3, $hashtable4
 
         Register-PSResourceRepository -Repositories $arrayOfHashtables
         $res = Get-PSResourceRepository -Name "testRepository"
@@ -95,6 +108,13 @@ Describe "Test Register-PSResourceRepository" {
         $res3.URL | Should -Contain $tmpDir3Path
         $res3.Trusted | Should -Be True
         $res3.Priority | Should -Be 20
+
+        $res4 = Get-PSResourceRepository -Name "testRepository4"
+        $res4.URL | Should -Contain $tmpDir4Path
+        $res4.Trusted | Should -Be True
+        $res4.Priority | Should -Be 30
+        $res4.Authentication["VaultName"] | Should -Be "testvault"
+        $res4.Authentication["Secret"] | Should -Be "testsecret"
     }
 
     It "register repositories with Repositories parameter, psgallery style repository (RepositoriesParameterSet)" {
@@ -113,7 +133,8 @@ Describe "Test Register-PSResourceRepository" {
         $hashtable2 = @{Name = "testRepository"; URL = $tmpDir1Path}
         $hashtable3 = @{Name = "testRepository2"; URL = $tmpDir2Path; Trusted = $True}
         $hashtable4 = @{Name = "testRepository3"; URL = $tmpDir3Path; Trusted = $True; Priority = 20}
-        $arrayOfHashtables = $hashtable1, $hashtable2, $hashtable3, $hashtable4
+        $hashtable5 = @{Name = "testRepository4"; URL = $tmpDir4Path; Trusted = $True; Priority = 30; Authentication = @{VaultName = "testvault"; Secret = "testsecret"}}
+        $arrayOfHashtables = $hashtable1, $hashtable2, $hashtable3, $hashtable4, $hashtable5
 
         Register-PSResourceRepository -Repositories $arrayOfHashtables
 
@@ -136,6 +157,13 @@ Describe "Test Register-PSResourceRepository" {
         $res4.URL | Should -Contain $tmpDir3Path
         $res4.Trusted | Should -Be True
         $res4.Priority | Should -Be 20
+
+        $res5 = Get-PSResourceRepository -Name "testRepository4"
+        $res5.URL | Should -Contain $tmpDir4Path
+        $res5.Trusted | Should -Be True
+        $res5.Priority | Should -Be 30
+        $res5.Authentication["VaultName"] | Should -Be "testvault"
+        $res5.Authentication["Secret"] | Should -Be "testsecret"
     }
 
     It "not register repository when Name is provided but URL is not" {
@@ -146,7 +174,7 @@ Describe "Test Register-PSResourceRepository" {
         {Register-PSResourceRepository -Name "" -URL $tmpDir1Path -ErrorAction Stop} | Should -Throw -ErrorId "ParameterArgumentValidationError,Microsoft.PowerShell.PowerShellGet.Cmdlets.RegisterPSResourceRepository"
     }
 
-    It "not register rpeository when Name is null but URL is provided" {
+    It "not register repository when Name is null but URL is provided" {
         {Register-PSResourceRepository -Name $null -URL $tmpDir1Path -ErrorAction Stop} | Should -Throw -ErrorId "ParameterArgumentValidationError,Microsoft.PowerShell.PowerShellGet.Cmdlets.RegisterPSResourceRepository"
     }
 
@@ -154,18 +182,30 @@ Describe "Test Register-PSResourceRepository" {
         {Register-PSResourceRepository -Name " " -URL $tmpDir1Path -ErrorAction Stop} | Should -Throw -ErrorId "ErrorInNameParameterSet,Microsoft.PowerShell.PowerShellGet.Cmdlets.RegisterPSResourceRepository"
     }
 
+    It "not register if Authentication is missing VaultName or Secret" {
+        {Register-PSResourceRepository -Name "testRepository" -URL $tmpDir1Path -Authentication @{Secret = "test"} -ErrorAction Stop} | Should -Throw -ErrorId "ErrorInNameParameterSet,Microsoft.PowerShell.PowerShellGet.Cmdlets.RegisterPSResourceRepository"
+        {Register-PSResourceRepository -Name "testRepository" -URL $tmpDir1Path -Authentication @{VaultName = "test"} -ErrorAction Stop} | Should -Throw -ErrorId "ErrorInNameParameterSet,Microsoft.PowerShell.PowerShellGet.Cmdlets.RegisterPSResourceRepository"
+    }
+
+    It "not register if Authentication values are empty" {
+        {Register-PSResourceRepository -Name "testRepository" -URL $tmpDir1Path -Authentication @{VaultName = "test"; Secret = ""} -ErrorAction Stop} | Should -Throw -ErrorId "ErrorInNameParameterSet,Microsoft.PowerShell.PowerShellGet.Cmdlets.RegisterPSResourceRepository"
+        {Register-PSResourceRepository -Name "testRepository" -URL $tmpDir1Path -Authentication @{VaultName = ""; Secret = "test"} -ErrorAction Stop} | Should -Throw -ErrorId "ErrorInNameParameterSet,Microsoft.PowerShell.PowerShellGet.Cmdlets.RegisterPSResourceRepository"
+    }
+
     It "not register PSGallery with NameParameterSet" {
         {Register-PSResourceRepository -Name $PSGalleryName -URL $PSGalleryURL -ErrorAction Stop} | Should -Throw -ErrorId "ErrorInNameParameterSet,Microsoft.PowerShell.PowerShellGet.Cmdlets.RegisterPSResourceRepository"
     }
 
     # this error message comes from the parameter cmdlet tags (earliest point of detection)
-    It "not register PSGallery when PSGallery parameter provided with Name or URL" {
+    It "not register PSGallery when PSGallery parameter provided with Name, URL or Authentication" {
         {Register-PSResourceRepository -PSGallery -Name $PSGalleryName -ErrorAction Stop} | Should -Throw -ErrorId "AmbiguousParameterSet,Microsoft.PowerShell.PowerShellGet.Cmdlets.RegisterPSResourceRepository"
         {Register-PSResourceRepository -PSGallery -URL $PSGalleryURL -ErrorAction Stop} | Should -Throw -ErrorId "AmbiguousParameterSet,Microsoft.PowerShell.PowerShellGet.Cmdlets.RegisterPSResourceRepository"
+        {Register-PSResourceRepository -PSGallery -Authentication @{VaultName = "testvault"; Secret = "testsecret"} -ErrorAction Stop} | Should -Throw -ErrorId "AmbiguousParameterSet,Microsoft.PowerShell.PowerShellGet.Cmdlets.RegisterPSResourceRepository"
     }
 
     $testCases = @{Type = "Name key specified with PSGallery key"; IncorrectHashTable = @{PSGallery = $True; Name=$PSGalleryName}},
-                 @{Type = "URL key specified with PSGallery key";  IncorrectHashTable = @{PSGallery = $True; URL=$PSGalleryURL}}
+                 @{Type = "URL key specified with PSGallery key";  IncorrectHashTable = @{PSGallery = $True; URL=$PSGalleryURL}},
+                 @{Type = "Authentication key specified with PSGallery key";  IncorrectHashTable = @{PSGallery = $True; Authentication = @{VaultName = "test"; Secret = "test"}}}
 
     It "not register incorrectly formatted PSGallery type repo among correct ones when incorrect type is <Type>" -TestCases $testCases {
         param($Type, $IncorrectHashTable)
@@ -178,7 +218,7 @@ Describe "Test Register-PSResourceRepository" {
         Unregister-PSResourceRepository -Name "PSGallery"
         Register-PSResourceRepository -Repositories $arrayOfHashtables -ErrorVariable err -ErrorAction SilentlyContinue
         $err.Count | Should -Not -Be 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "NotProvideNameUrlForPSGalleryRepositoriesParameterSetRegistration,Microsoft.PowerShell.PowerShellGet.Cmdlets.RegisterPSResourceRepository"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "NotProvideNameUrlAuthForPSGalleryRepositoriesParameterSetRegistration,Microsoft.PowerShell.PowerShellGet.Cmdlets.RegisterPSResourceRepository"
 
         $res = Get-PSResourceRepository -Name "testRepository"
         $res.Name | Should -Be "testRepository"
@@ -190,10 +230,14 @@ Describe "Test Register-PSResourceRepository" {
         $res3.Name | Should -Be "testRepository3"
     }
 
-    $testCases2 = @{Type = "-Name is not specified";                 IncorrectHashTable = @{URL = $tmpDir1Path};                             ErrorId = "NullNameForRepositoriesParameterSetRegistration,Microsoft.PowerShell.PowerShellGet.Cmdlets.RegisterPSResourceRepository"},
-                  @{Type = "-Name is PSGallery";                     IncorrectHashTable = @{Name = "PSGallery"; URL = $tmpDir1Path};         ErrorId = "PSGalleryProvidedAsNameRepoPSet,Microsoft.PowerShell.PowerShellGet.Cmdlets.RegisterPSResourceRepository"},
-                  @{Type = "-URL not specified";                     IncorrectHashTable = @{Name = "testRepository"};                        ErrorId = "NullURLForRepositoriesParameterSetRegistration,Microsoft.PowerShell.PowerShellGet.Cmdlets.RegisterPSResourceRepository"},
-                  @{Type = "-URL is not valid scheme";               IncorrectHashTable = @{Name = "testRepository"; URL="www.google.com"};  ErrorId = "InvalidUrlScheme,Microsoft.PowerShell.PowerShellGet.Cmdlets.RegisterPSResourceRepository"}
+    $testCases2 = @{Type = "-Name is not specified";                    IncorrectHashTable = @{URL = $tmpDir1Path};                                                                              ErrorId = "NullNameForRepositoriesParameterSetRegistration,Microsoft.PowerShell.PowerShellGet.Cmdlets.RegisterPSResourceRepository"},
+                  @{Type = "-Name is PSGallery";                        IncorrectHashTable = @{Name = "PSGallery"; URL = $tmpDir1Path};                                                          ErrorId = "PSGalleryProvidedAsNameRepoPSet,Microsoft.PowerShell.PowerShellGet.Cmdlets.RegisterPSResourceRepository"},
+                  @{Type = "-URL not specified";                        IncorrectHashTable = @{Name = "testRepository"};                                                                         ErrorId = "NullURLForRepositoriesParameterSetRegistration,Microsoft.PowerShell.PowerShellGet.Cmdlets.RegisterPSResourceRepository"},
+                  @{Type = "-URL is not valid scheme";                  IncorrectHashTable = @{Name = "testRepository"; URL="www.google.com"};                                                   ErrorId = "InvalidUrlScheme,Microsoft.PowerShell.PowerShellGet.Cmdlets.RegisterPSResourceRepository"},
+                  @{Type = "-Authentication is missing VaultName";      IncorrectHashTable = @{Name = "testRepository"; URL=$tmpDir1Path; Authentication = @{Secret = "test"}};                  ErrorId = "InvalidAuthentication,Microsoft.PowerShell.PowerShellGet.Cmdlets.RegisterPSResourceRepository"},
+                  @{Type = "-Authentication is missing Secret";         IncorrectHashTable = @{Name = "testRepository"; URL=$tmpDir1Path; Authentication = @{VaultName = "test"}};               ErrorId = "InvalidAuthentication,Microsoft.PowerShell.PowerShellGet.Cmdlets.RegisterPSResourceRepository"},
+                  @{Type = "-Authentication-VaultName value is empty";  IncorrectHashTable = @{Name = "testRepository"; URL=$tmpDir1Path; Authentication = @{VaultName = ""; Secret = "test"}};  ErrorId = "InvalidAuthentication,Microsoft.PowerShell.PowerShellGet.Cmdlets.RegisterPSResourceRepository"},
+                  @{Type = "-Authentication-Secret value is empty";     IncorrectHashTable = @{Name = "testRepository"; URL=$tmpDir1Path; Authentication = @{VaultName = "test"; Secret = ""}};  ErrorId = "InvalidAuthentication,Microsoft.PowerShell.PowerShellGet.Cmdlets.RegisterPSResourceRepository"}
 
     It "not register incorrectly formatted Name type repo among correct ones when incorrect type is <Type>" -TestCases $testCases2 {
         param($Type, $IncorrectHashTable, $ErrorId)

--- a/test/SetPSResourceRepository.Tests.ps1
+++ b/test/SetPSResourceRepository.Tests.ps1
@@ -3,7 +3,7 @@
 
 Import-Module "$psscriptroot\PSGetTestUtils.psm1" -Force
 
-Describe "Test Register-PSResourceRepository" {
+Describe "Test Set-PSResourceRepository" {
     BeforeEach {
         $PSGalleryName = Get-PSGalleryName
         $PSGalleryURL = Get-PSGalleryLocation
@@ -11,7 +11,8 @@ Describe "Test Register-PSResourceRepository" {
         $tmpDir1Path = Join-Path -Path $TestDrive -ChildPath "tmpDir1"
         $tmpDir2Path = Join-Path -Path $TestDrive -ChildPath "tmpDir2"
         $tmpDir3Path = Join-Path -Path $TestDrive -ChildPath "tmpDir3"
-        $tmpDirPaths = @($tmpDir1Path, $tmpDir2Path, $tmpDir3Path)
+        $tmpDir4Path = Join-Path -Path $TestDrive -ChildPath "tmpDir4"
+        $tmpDirPaths = @($tmpDir1Path, $tmpDir2Path, $tmpDir3Path, $tmpDir4Path)
         Get-NewTestDirs($tmpDirPaths)
     }
     AfterEach {
@@ -19,7 +20,8 @@ Describe "Test Register-PSResourceRepository" {
         $tmpDir1Path = Join-Path -Path $TestDrive -ChildPath "tmpDir1"
         $tmpDir2Path = Join-Path -Path $TestDrive -ChildPath "tmpDir2"
         $tmpDir3Path = Join-Path -Path $TestDrive -ChildPath "tmpDir3"
-        $tmpDirPaths = @($tmpDir1Path, $tmpDir2Path, $tmpDir3Path)
+        $tmpDir4Path = Join-Path -Path $TestDrive -ChildPath "tmpDir4"
+        $tmpDirPaths = @($tmpDir1Path, $tmpDir2Path, $tmpDir3Path, $tmpDir4Path)
         Get-RemoveTestDirs($tmpDirPaths)
     }
 
@@ -31,6 +33,7 @@ Describe "Test Register-PSResourceRepository" {
         $res.URL | Should -Contain $tmpDir2Path
         $res.Priority | Should -Be 50
         $res.Trusted | Should -Be False
+        $res.Authentication | Should -BeNullOrEmpty
     }
 
     It "set repository given Name and Priority parameters" {
@@ -41,6 +44,7 @@ Describe "Test Register-PSResourceRepository" {
         $res.URL | Should -Contain $tmpDir1Path
         $res.Priority | Should -Be 25
         $res.Trusted | Should -Be False
+        $res.Authentication | Should -BeNullOrEmpty
     }
 
     It "set repository given Name and Trusted parameters" {
@@ -51,6 +55,19 @@ Describe "Test Register-PSResourceRepository" {
         $res.URL | Should -Contain $tmpDir1Path
         $res.Priority | Should -Be 50
         $res.Trusted | Should -Be True
+        $res.Authentication | Should -BeNullOrEmpty
+    }
+
+    It "set repository given Name and Authentication parameters" {
+        Register-PSResourceRepository -Name "testRepository" -URL $tmpDir1Path
+        Set-PSResourceRepository -Name "testRepository" -Authentication @{VaultName = "test"; Secret = "test"}
+        $res = Get-PSResourceRepository -Name "testRepository"
+        $res.Name | Should -Be "testRepository"
+        $res.URL | Should -Contain $tmpDir1Path
+        $res.Priority | Should -Be 50
+        $res.Trusted | Should -Be False
+        $res.Authentication["VaultName"] | Should -Be "test"
+        $res.Authentication["Secret"] | Should -Be "test"
     }
 
     It "not set repository and write error given just Name parameter" {
@@ -100,12 +117,14 @@ Describe "Test Register-PSResourceRepository" {
         Unregister-PSResourceRepository -Name "PSGallery"
         Register-PSResourceRepository -Name "testRepository1" -URL $tmpDir1Path
         Register-PSResourceRepository -Name "testRepository2" -URL $tmpDir2Path
+        Register-PSResourceRepository -Name "testRepository3" -URL $tmpDir3Path
         Register-PSResourceRepository -PSGallery
 
         $hashtable1 = @{Name = "testRepository1"; URL = $tmpDir2Path};
         $hashtable2 = @{Name = "testRepository2"; Priority = 25};
-        $hashtable3 = @{Name = "PSGallery"; Trusted = $True};
-        $arrayOfHashtables = $hashtable1, $hashtable2, $hashtable3
+        $hashtable3 = @{Name = "testRepository3"; Authentication = @{VaultName = "test"; Secret = "test"}};
+        $hashtable4 = @{Name = "PSGallery"; Trusted = $True};
+        $arrayOfHashtables = $hashtable1, $hashtable2, $hashtable3, $hashtable4
 
         Set-PSResourceRepository -Repositories $arrayOfHashtables
         $res = Get-PSResourceRepository -Name "testRepository1"
@@ -113,24 +132,41 @@ Describe "Test Register-PSResourceRepository" {
         $res.URL | Should -Contain $tmpDir2Path
         $res.Priority | Should -Be 50
         $res.Trusted | Should -Be False
+        $res.Authentication | Should -BeNullOrEmpty
 
         $res2 = Get-PSResourceRepository -Name "testRepository2"
         $res2.Name | Should -Be "testRepository2"
         $res2.URL | Should -Contain $tmpDir2Path
         $res2.Priority | Should -Be 25
         $res2.Trusted | Should -Be False
+        $res2.Authentication | Should -BeNullOrEmpty
 
-        $res3 = Get-PSResourceRepository -Name $PSGalleryName
-        $res3.Name | Should -Be $PSGalleryName
-        $res3.URL | Should -Contain $PSGalleryURL
+        $res3 = Get-PSResourceRepository -Name "testRepository3"
+        $res3.Name | Should -Be "testRepository3"
+        $res3.URL | Should -Contain $tmpDir3Path
         $res3.Priority | Should -Be 50
-        $res3.Trusted | Should -Be True
+        $res3.Trusted | Should -Be False
+        $res3.Authentication["VaultName"] | Should -Be "test"
+        $res3.Authentication["Secret"] | Should -Be "test"
+
+        $res4 = Get-PSResourceRepository -Name $PSGalleryName
+        $res4.Name | Should -Be $PSGalleryName
+        $res4.URL | Should -Contain $PSGalleryURL
+        $res4.Priority | Should -Be 50
+        $res4.Trusted | Should -Be True
+        $res4.Authentication | Should -BeNullOrEmpty
     }
 
     It "not set and throw error for trying to set PSGallery URL (NameParameterSet)" {
         Unregister-PSResourceRepository -Name "PSGallery"
         Register-PSResourceRepository -PSGallery
         {Set-PSResourceRepository -Name "PSGallery" -URL $tmpDir1Path -ErrorAction Stop} | Should -Throw -ErrorId "ErrorInNameParameterSet,Microsoft.PowerShell.PowerShellGet.Cmdlets.SetPSResourceRepository"
+    }
+
+    It "not set and throw error for trying to set PSGallery Authentication (NameParameterSet)" {
+        Unregister-PSResourceRepository -Name "PSGallery"
+        Register-PSResourceRepository -PSGallery
+        {Set-PSResourceRepository -Name "PSGallery" -Authentication @{VaultName = "test"; Secret = "test"} -ErrorAction Stop} | Should -Throw -ErrorId "ErrorInNameParameterSet,Microsoft.PowerShell.PowerShellGet.Cmdlets.SetPSResourceRepository"
     }
 
     It "not set repository and throw error for trying to set PSGallery URL (RepositoriesParameterSet)" {
@@ -151,5 +187,64 @@ Describe "Test Register-PSResourceRepository" {
         $res.URL | Should -Contain $tmpDir1Path
         $res.Priority | Should -Be 25
         $res.Trusted | Should -Be False
+    }
+
+    It "not set repository and throw error for trying to set PSGallery Authentication (RepositoriesParameterSet)" {
+        Unregister-PSResourceRepository -Name "PSGallery"
+        Register-PSResourceRepository -PSGallery
+
+        Register-PSResourceRepository -Name "testRepository" -URL $tmpDir1Path
+
+        $hashtable1 = @{Name = "PSGallery"; Authentication = @{VaultName = "test"; Secret = "test"}}
+        $hashtable2 = @{Name = "testRepository"; Priority = 25}
+        $arrayOfHashtables = $hashtable1, $hashtable2
+
+        Set-PSResourceRepository -Repositories $arrayOfHashtables -ErrorVariable err -ErrorAction SilentlyContinue
+        $err.Count | Should -Not -Be 0
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "ErrorSettingIndividualRepoFromRepositories,Microsoft.PowerShell.PowerShellGet.Cmdlets.SetPSResourceRepository"
+
+        $res = Get-PSResourceRepository -Name "testRepository"
+        $res.URL | Should -Contain $tmpDir1Path
+        $res.Priority | Should -Be 25
+        $res.Trusted | Should -Be False
+        $res.Authentication | Should -BeNullOrEmpty
+    }
+
+    It "not set and throw error if Authentication is invalid (NameParameterSet)" {
+        Register-PSResourceRepository -Name "testRepository" -URL $tmpDir1Path
+        {Set-PSResourceRepository -Name "testRepository" -Authentication @{VaultName = "test"} -ErrorAction Stop} | Should -Throw -ErrorId "ErrorInNameParameterSet,Microsoft.PowerShell.PowerShellGet.Cmdlets.SetPSResourceRepository"
+        {Set-PSResourceRepository -Name "testRepository" -Authentication @{VaultName = "test"; Secret = ""} -ErrorAction Stop} | Should -Throw -ErrorId "ErrorInNameParameterSet,Microsoft.PowerShell.PowerShellGet.Cmdlets.SetPSResourceRepository"
+    }
+
+    It "not set and throw error if Authentication is invalid (RepositoriesParameterSet)" {
+        Register-PSResourceRepository -Name "testRepository1" -URL $tmpDir1Path
+        Register-PSResourceRepository -Name "testRepository2" -URL $tmpDir2Path
+        Register-PSResourceRepository -Name "testRepository3" -URL $tmpDir3Path
+        Register-PSResourceRepository -Name "testRepository4" -URL $tmpDir4Path
+
+        $hashtable1 = @{Name = "testRepository1"; Priority = 25}
+        $hashtable2 = @{Name = "testRepository2"; Authentication = @{Secret = ""}}
+        $hashtable3 = @{Name = "testRepository3"; Authentication = @{VaultName = "test"; Secret = ""}}
+        $hashtable4 = @{Name = "testRepository4"; Authentication = @{}}
+        $arrayOfHashtables = $hashtable1, $hashtable2, $hashtable3, $hashtable4
+
+        Set-PSResourceRepository -Repositories $arrayOfHashtables -ErrorVariable err -ErrorAction SilentlyContinue
+        $err.Count | Should -Not -Be 0
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "ErrorSettingIndividualRepoFromRepositories,Microsoft.PowerShell.PowerShellGet.Cmdlets.SetPSResourceRepository"
+
+        $res = Get-PSResourceRepository -Name "testRepository1"
+        $res.URL | Should -Contain $tmpDir1Path
+        $res.Priority | Should -Be 25
+        $res.Trusted | Should -Be False
+        $res.Authentication | Should -BeNullOrEmpty
+
+        $res2 = Get-PSResourceRepository -Name "testRepository2"
+        $res2.Authentication | Should -BeNullOrEmpty
+
+        $res3 = Get-PSResourceRepository -Name "testRepository3"
+        $res3.Authentication | Should -BeNullOrEmpty
+
+        $res4 = Get-PSResourceRepository -Name "testRepository4"
+        $res4.Authentication | Should -BeNullOrEmpty
     }
 }

--- a/test/UnregisterPSResourceRepository.Tests.ps1
+++ b/test/UnregisterPSResourceRepository.Tests.ps1
@@ -3,7 +3,7 @@
 
 Import-Module "$psscriptroot\PSGetTestUtils.psm1" -Force
 
-Describe "Test Register-PSResourceRepository" {
+Describe "Test Unregister-PSResourceRepository" {
     BeforeEach {
         Get-NewPSResourceRepositoryFile
         $tmpDir1Path = Join-Path -Path $TestDrive -ChildPath "tmpDir1"

--- a/test/testRepositories.xml
+++ b/test/testRepositories.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <Repository Name="psgettestlocal"  Url="file:///c:/code/testdir"                  Priority="50" Trusted="false" />
+  <Repository Name="psgettestlocal2" Url="file:///c:/code/testdir2"                 Priority="60" Trusted="false" VaultName="testvault" Secret="testsecret" />
+  <Repository Name="psgettestlocal3" Url="file:///c:/code/testdir3"                 Priority="70" Trusted="false" VaultName="testvault" />
+  <Repository Name="psgettestlocal4" Url="file:///c:/code/testdir4"                 Priority="80" Trusted="false" VaultName="testvault" Secret="" />
   <Repository Name="PSGallery"       Url="https://www.powershellgallery.com/api/v2" Priority="50" Trusted="false" />
   <Repository Name="PoshTestGallery" Url="https://www.poshtestgallery.com/api/v2"   Priority="10" Trusted="true"  />
 </configuration>


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Addressing the first part of the proposal in the Credential Persistence issue:
```
- Add an -Authentication parameter to the Register-PSResourceRepository
- Add an authentication dimension to the PSRespositoryItem object
- The -Authentication parameter will take a hashtable which specifies the vault and secret where the credential is store
```

## PR Context

These changes are to store secret vault and secret name information as part of the PSResourceRepository. Nothing else is done with this information just yet.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.


### NOTE: I will be out until after the summer break so there is no rush to review this PR.